### PR TITLE
virtualFile partial support for Seek

### DIFF
--- a/file.go
+++ b/file.go
@@ -26,8 +26,12 @@ func (f virtualFile) Name() string {
 	return f.name
 }
 
-func (f virtualFile) Seek(offset int64, whence int) (int64, error) {
-	return -1, nil
+func (f *virtualFile) Seek(offset int64, whence int) (int64, error) {
+	if offset == 0 && whence == io.SeekStart {
+		f.buf = bytes.NewBuffer(f.original)
+		return 0, nil
+	}
+	return -1, errors.New("Unsuported Seek operation")
 }
 
 func (f virtualFile) FileInfo() (os.FileInfo, error) {

--- a/file_test.go
+++ b/file_test.go
@@ -52,3 +52,39 @@ func Test_File_Writer(t *testing.T) {
 
 	r.Equal("HELLO", f.String())
 }
+
+func Test_File_Seek(t *testing.T) {
+	r := require.New(t)
+	input := "Aliqua adipisicing ullamco anim culpa minim labore sunt nostrud et exercitation veniam amet."
+	f, err := NewFile("foo.txt", strings.NewReader(input))
+	r.NoError(err)
+	r.Equal(input, f.String())
+
+	// Perform first read
+	buf := make([]byte, 6)
+	n, err := f.Read(buf)
+	r.NoError(err)
+	r.Equal(6, n)
+	r.Equal("Aliqua", string(buf))
+
+	// Seek back to beginning
+	i, err := f.Seek(0, io.SeekStart)
+	r.NoError(err)
+	r.Equal(int64(0), i)
+
+	// read again
+	buf = make([]byte, 6)
+	n, err = f.Read(buf)
+	r.NoError(err)
+	r.Equal(6, n)
+	r.Equal("Aliqua", string(buf))
+
+	// Check that unsupported arguments return an error
+	i, err = f.Seek(-12, io.SeekCurrent)
+	r.Error(err)
+	r.Equal(int64(-1), i)
+
+	i, err = f.Seek(12, io.SeekCurrent)
+	r.Error(err)
+	r.Equal(int64(-1), i)
+}


### PR DESCRIPTION
`virtualFile` partially support Seek operation, only with offset `0`, and `io.SeekStart` arguments.
Any other attempt to call it with unsupported arguments will return an error

Closes #5 