### PR TITLE
fixed repeated reading

### DIFF
--- a/file.go
+++ b/file.go
@@ -51,12 +51,7 @@ func (f virtualFile) String() string {
 // Read reads the next len(p) bytes from the virtualFile and
 // rewind read offset to 0 when it met EOF.
 func (f *virtualFile) Read(p []byte) (int, error) {
-	i, err := f.Reader.Read(p)
-
-	if i == 0 || err == io.EOF {
-		f.Seek(0, io.SeekStart)
-	}
-	return i, err
+	return f.Reader.Read(p)
 }
 
 // Write copies byte slice p to content of virtualFile.

--- a/file_test.go
+++ b/file_test.go
@@ -38,12 +38,18 @@ func Test_File_Reader(t *testing.T) {
 	r.Equal(input, bb.String())
 	r.Equal(input, f.String())
 
+	// eof
+	buf := make([]byte, 2)
+	n, err := f.Read(buf)
+	r.Equal(0, n)
+	r.Error(err, io.EOF.Error())
+
 	// read again
 	bb2 := &bytes.Buffer{}
 	i, err = io.Copy(bb2, f)
 	r.NoError(err)
-	r.Equal(int64(2), i)
-	r.Equal(input, bb2.String())
+	r.Equal(int64(0), i)
+	r.Empty(bb2.String())
 	r.Equal(input, f.String())
 }
 


### PR DESCRIPTION
Correct behavior of a read function on repeated calls.

Related issue https://github.com/gobuffalo/packr/issues/249